### PR TITLE
Secure websockets

### DIFF
--- a/lib/cli/local/index.js
+++ b/lib/cli/local/index.js
@@ -295,7 +295,7 @@ module.exports.handler = function(argv) {
         , '--vnc-initial-size', argv.vncInitialSize.join('x')
         , '--mute-master', argv.muteMaster
         ]
-        .concat(config.env !== 'dev' ? ['--screen-ws-url-pattern=ws://${publicIp}/websocket/${publicPort}'] : [])
+        .concat(config.env !== 'dev' ? ['--screen-ws-url-pattern=wss://${publicIp}/websocket/${publicPort}'] : [])
         .concat(argv.allowRemote ? ['--allow-remote'] : [])
         .concat(argv.lockRotation ? ['--lock-rotation'] : [])
         .concat(!argv.cleanup ? ['--no-cleanup'] : [])
@@ -329,9 +329,10 @@ module.exports.handler = function(argv) {
           }[argv.authType] || argv.authType
           )
         , '--websocket-url', util.format(
-            'http://%s:%d/'
+            '%s://%s:%d/'
+          , config.env !== 'dev' ? 'https' : 'http'
           , argv.publicIp
-          , config.env !== 'dev' ? 80 : argv.websocketPort
+          , config.env !== 'dev' ? 443 : argv.websocketPort
           )
         , '--connect-sub', argv.bindAppPub
         , '--connect-push', argv.bindAppPull

--- a/res/app/components/stf/socket/socket-service.js
+++ b/res/app/components/stf/socket/socket-service.js
@@ -8,7 +8,9 @@ module.exports = function SocketFactory(
   var websocketUrl = AppState.config.websocketUrl || ''
 
   var socket = io(websocketUrl, {
-    reconnection: false, transports: ['websocket']
+    reconnection: false,
+    transports: ['websocket'],
+    secure: true
   })
 
   socket.setWSId = function(wsId){


### PR DESCRIPTION
Convert ws links to wss (except on dev environment). Once this change is applied, nginx config should be modified to serve stf over https.